### PR TITLE
Change progress_bar.md title to be consistent

### DIFF
--- a/docs/component_APIs/progress_bar.md
+++ b/docs/component_APIs/progress_bar.md
@@ -1,4 +1,4 @@
-# Progress Bar
+# ProgressBar
 
 A bar that shows the progress in a certain task, 0-100.
 


### PR DESCRIPTION
Other files with a two word title format them like `TextInput` or `RadioButtons` whereas this file has `Progress Bar`