### PR TITLE
Added standalone example app.

### DIFF
--- a/examples/Notepad/.babelrc
+++ b/examples/Notepad/.babelrc
@@ -1,0 +1,7 @@
+{
+    "presets": [
+      "env",
+      "stage-0",
+      "react"
+    ]
+}

--- a/examples/Notepad/index.js
+++ b/examples/Notepad/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import fs from 'fs'
-import { render, Window, App, TextInput, Dialog, Menu, Box } from '../src/';
+import { render, Window, App, TextInput, Dialog, Menu, Box } from 'proton-native';
 
-class Example extends Component {
+class Notepad extends Component {
     state = {text: ''}
 
     save() {
@@ -34,4 +34,4 @@ class Example extends Component {
   }
 }
 
-render(<Example />);
+render(<Notepad />);

--- a/examples/Notepad/package.json
+++ b/examples/Notepad/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "notepad",
+    "version": "1.0.0",
+    "description": "a notepad app built using proton-native",
+    "main": "index.js",
+    "dependencies": {
+      "proton-native": "^1.0.11"
+    },
+    "devDependencies": {},
+    "scripts": {
+      "start": "node_modules/.bin/babel-node index.js"
+    },
+    "author": "",
+    "license": "ISC"
+}
+  


### PR DESCRIPTION
Hey there,

The example inside the examples folder was just a file, i've added a full application project inside an appropriately named sub folder ( Notepad ) as an example, so that the user only needs to do npm install and then do npm start to get an example application up and running. Hope that adds value.

Appreciate the great work on the library once again!. :) 👍 