### PR TITLE
Use React event naming conventions

### DIFF
--- a/bin/components/Button.js
+++ b/bin/components/Button.js
@@ -36,7 +36,7 @@ var Button = function (_DesktopComponent) {
 
     var _this = _possibleConstructorReturn(this, (Button.__proto__ || Object.getPrototypeOf(Button)).call(this, root, props));
 
-    _this.eventParameter = { onClicked: 'text' };
+    _this.eventParameter = { onClick: 'text' };
     _this.childName = 'text';
 
     _this.root = root;
@@ -61,14 +61,14 @@ var Button = function (_DesktopComponent) {
 Button.PropTypes = _extends({
   enabled: _propTypes2.default.bool,
   visible: _propTypes2.default.bool,
-  onClicked: _propTypes2.default.func,
+  onClick: _propTypes2.default.func,
   children: _propTypes2.default.string
 }, _DesktopComponent2.universalPropTypes);
 
 Button.defaultProps = _extends({
   enabled: true,
   visible: true,
-  onClicked: function onClicked() {},
+  onClick: function onClick() {},
   children: ''
 }, _DesktopComponent2.universalDefaultProps);
 

--- a/bin/components/ColorButton.js
+++ b/bin/components/ColorButton.js
@@ -40,7 +40,7 @@ var ColorButton = function (_DesktopComponent) {
 
     var _this = _possibleConstructorReturn(this, (ColorButton.__proto__ || Object.getPrototypeOf(ColorButton)).call(this, root, props));
 
-    _this.eventParameter = { onChanged: 'color' };
+    _this.eventParameter = { onChange: 'color' };
 
     _this.root = root;
     _this.props = _extends({}, props);
@@ -142,12 +142,12 @@ var ColorButton = function (_DesktopComponent) {
 
 ColorButton.PropTypes = _extends({
   color: _propTypes2.default.string,
-  onChanged: _propTypes2.default.func
+  onChange: _propTypes2.default.func
 }, _DesktopComponent2.universalPropTypes);
 
 ColorButton.defaultProps = _extends({
   color: 'black',
-  onChanged: function onChanged() {}
+  onChange: function onChange() {}
 }, _DesktopComponent2.universalDefaultProps);
 
 exports.default = ColorButton;

--- a/bin/components/EditableCombobox.js
+++ b/bin/components/EditableCombobox.js
@@ -36,7 +36,7 @@ var EditableCombobox = function (_DesktopComponent) {
 
     var _this = _possibleConstructorReturn(this, (EditableCombobox.__proto__ || Object.getPrototypeOf(EditableCombobox)).call(this, root, props));
 
-    _this.eventParameter = { onChanged: 'text' };
+    _this.eventParameter = { onChange: 'text' };
 
     _this.root = root;
     _this.props = _extends({}, props);
@@ -62,14 +62,14 @@ EditableCombobox.PropTypes = _extends({
   enabled: _propTypes2.default.bool,
   visible: _propTypes2.default.bool,
   text: _propTypes2.default.string,
-  onChanged: _propTypes2.default.func
+  onChange: _propTypes2.default.func
 }, _DesktopComponent3.universalPropTypes);
 
 EditableCombobox.defaultProps = _extends({
   enabled: true,
   visible: true,
   text: '',
-  onChanged: function onChanged() {}
+  onChange: function onChange() {}
 }, _DesktopComponent3.universalDefaultProps);
 
 EditableCombobox.Item = function (_DesktopComponent2) {

--- a/bin/components/Entry.js
+++ b/bin/components/Entry.js
@@ -36,7 +36,7 @@ var Entry = function (_DesktopComponent) {
 
     var _this = _possibleConstructorReturn(this, (Entry.__proto__ || Object.getPrototypeOf(Entry)).call(this, root, props));
 
-    _this.eventParameter = { onChanged: 'text' };
+    _this.eventParameter = { onChange: 'text' };
     _this.childName = 'text';
 
     _this.root = root;
@@ -62,7 +62,7 @@ Entry.PropTypes = _extends({
   enabled: _propTypes2.default.bool,
   visible: _propTypes2.default.bool,
   readOnly: _propTypes2.default.bool,
-  onChanged: _propTypes2.default.func,
+  onChange: _propTypes2.default.func,
   children: _propTypes2.default.string
 }, _DesktopComponent2.universalPropTypes);
 
@@ -70,7 +70,7 @@ Entry.defaultProps = _extends({
   enabled: true,
   visible: true,
   readOnly: false,
-  onChanged: function onChanged() {},
+  onChange: function onChange() {},
   children: ''
 }, _DesktopComponent2.universalDefaultProps);
 

--- a/bin/components/FontButton.js
+++ b/bin/components/FontButton.js
@@ -36,7 +36,7 @@ var FontButton = function (_DesktopComponent) {
 
     var _this = _possibleConstructorReturn(this, (FontButton.__proto__ || Object.getPrototypeOf(FontButton)).call(this, root, props));
 
-    _this.eventParameter = { onChanged: function onChanged() {
+    _this.eventParameter = { onChange: function onChange() {
         return _this.element.getFont();
       } };
 
@@ -60,11 +60,11 @@ var FontButton = function (_DesktopComponent) {
 }(_DesktopComponent3.default);
 
 FontButton.PropTypes = _extends({
-  onChanged: _propTypes2.default.func
+  onChange: _propTypes2.default.func
 }, _DesktopComponent2.universalPropTypes);
 
 FontButton.defaultProps = _extends({
-  onChanged: function onChanged() {}
+  onChange: function onChange() {}
 }, _DesktopComponent2.universalDefaultProps);
 
 exports.default = FontButton;

--- a/bin/components/MenuBar.js
+++ b/bin/components/MenuBar.js
@@ -71,7 +71,7 @@ MenuBar.Item = function (_DesktopComponent2) {
 
     var _this2 = _possibleConstructorReturn(this, (Item.__proto__ || Object.getPrototypeOf(Item)).call(this, root, props));
 
-    _this2.eventParameter = { onClicked: 'checked' };
+    _this2.eventParameter = { onClick: 'checked' };
 
     _this2.root = root;
     _this2.props = _extends({}, props);
@@ -102,14 +102,14 @@ MenuBar.Item.PropTypes = _extends({
   children: _propTypes2.default.string,
   checked: _propTypes2.default.bool,
   type: _propTypes2.default.oneOf(['Check', 'Quit', 'About', 'Preferences', 'Separator', 'Item']),
-  onClicked: _propTypes2.default.func
+  onClick: _propTypes2.default.func
 }, _DesktopComponent3.universalPropTypes);
 
 MenuBar.Item.defaultProps = _extends({
   children: '',
   checked: false,
   type: 'Item',
-  onClicked: function onClicked() {}
+  onClick: function onClick() {}
 }, _DesktopComponent3.universalDefaultProps);
 
 exports.default = MenuBar;

--- a/bin/components/MultilineEntry.js
+++ b/bin/components/MultilineEntry.js
@@ -36,7 +36,7 @@ var MultilineEntry = function (_DesktopComponent) {
 
     var _this = _possibleConstructorReturn(this, (MultilineEntry.__proto__ || Object.getPrototypeOf(MultilineEntry)).call(this, root, props));
 
-    _this.eventParameter = { onChanged: 'text' };
+    _this.eventParameter = { onChange: 'text' };
     _this.childName = 'text';
 
     _this.root = root;
@@ -62,7 +62,7 @@ MultilineEntry.PropTypes = _extends({
   enabled: _propTypes2.default.bool,
   visible: _propTypes2.default.bool,
   readOnly: _propTypes2.default.bool,
-  onChanged: _propTypes2.default.func,
+  onChange: _propTypes2.default.func,
   children: _propTypes2.default.string
 }, _DesktopComponent2.universalPropTypes);
 
@@ -70,7 +70,7 @@ MultilineEntry.defaultProps = _extends({
   enabled: true,
   visible: true,
   readOnly: false,
-  onChanged: function onChanged() {},
+  onChange: function onChange() {},
   children: ''
 }, _DesktopComponent2.universalDefaultProps);
 

--- a/bin/components/PasswordEntry.js
+++ b/bin/components/PasswordEntry.js
@@ -36,7 +36,7 @@ var PasswordEntry = function (_DesktopComponent) {
 
     var _this = _possibleConstructorReturn(this, (PasswordEntry.__proto__ || Object.getPrototypeOf(PasswordEntry)).call(this, root, props));
 
-    _this.eventParameter = { onChanged: 'text' };
+    _this.eventParameter = { onChange: 'text' };
     _this.childName = 'text';
 
     _this.root = root;
@@ -62,7 +62,7 @@ PasswordEntry.PropTypes = _extends({
   enabled: _propTypes2.default.bool,
   visible: _propTypes2.default.bool,
   readOnly: _propTypes2.default.bool,
-  onChanged: _propTypes2.default.func,
+  onChange: _propTypes2.default.func,
   children: _propTypes2.default.string
 }, _DesktopComponent2.universalPropTypes);
 
@@ -70,7 +70,7 @@ PasswordEntry.defaultProps = _extends({
   enabled: true,
   visible: true,
   readOnly: false,
-  onChanged: function onChanged() {},
+  onChange: function onChange() {},
   children: ''
 }, _DesktopComponent2.universalDefaultProps);
 

--- a/bin/components/Slider.js
+++ b/bin/components/Slider.js
@@ -36,7 +36,7 @@ var Slider = function (_DesktopComponent) {
 
     var _this = _possibleConstructorReturn(this, (Slider.__proto__ || Object.getPrototypeOf(Slider)).call(this, root, props));
 
-    _this.eventParameter = { onChanged: 'value' };
+    _this.eventParameter = { onChange: 'value' };
 
     _this.root = root;
     _this.props = _extends({}, props);
@@ -61,14 +61,14 @@ Slider.PropTypes = _extends({
   enabled: _propTypes2.default.bool,
   visible: _propTypes2.default.bool,
   value: _propTypes2.default.number,
-  onChanged: _propTypes2.default.func
+  onChange: _propTypes2.default.func
 }, _DesktopComponent2.universalPropTypes);
 
 Slider.defaultProps = _extends({
   enabled: true,
   visible: true,
   value: 0,
-  onChanged: function onChanged() {}
+  onChange: function onChange() {}
 }, _DesktopComponent2.universalDefaultProps);
 
 exports.default = Slider;

--- a/bin/components/Spinbox.js
+++ b/bin/components/Spinbox.js
@@ -36,7 +36,7 @@ var Spinbox = function (_DesktopComponent) {
 
     var _this = _possibleConstructorReturn(this, (Spinbox.__proto__ || Object.getPrototypeOf(Spinbox)).call(this, root, props));
 
-    _this.eventParameter = { onChanged: 'value' };
+    _this.eventParameter = { onChange: 'value' };
 
     _this.root = root;
     _this.props = _extends({}, props);
@@ -61,14 +61,14 @@ Spinbox.PropTypes = _extends({
   enabled: _propTypes2.default.bool,
   visible: _propTypes2.default.bool,
   value: _propTypes2.default.number,
-  onChanged: _propTypes2.default.func
+  onChange: _propTypes2.default.func
 }, _DesktopComponent2.universalPropTypes);
 
 Spinbox.defaultProps = _extends({
   enabled: true,
   visible: true,
   value: 0,
-  onChanged: function onChanged() {}
+  onChange: function onChange() {}
 }, _DesktopComponent2.universalDefaultProps);
 
 exports.default = Spinbox;

--- a/bin/components/Window.js
+++ b/bin/components/Window.js
@@ -110,8 +110,8 @@ var Window = function (_DesktopComponent) {
           this.element.center();
         }
 
-        this.element.onPositionChanged(function () {
-          _this2.props.onPositionChanged({
+        this.element.onPositionChange(function () {
+          _this2.props.onPositionChange({
             x: _this2.element.position.x,
             y: _this2.element.position.y
           });
@@ -150,7 +150,7 @@ Window.PropTypes = {
   lastWindow: _propTypes2.default.bool,
   closed: _propTypes2.default.bool,
   onClosing: _propTypes2.default.func,
-  onPositionChanged: _propTypes2.default.func,
+  onPositionChange: _propTypes2.default.func,
   onContentSizeChanged: _propTypes2.default.func
 };
 
@@ -172,7 +172,7 @@ Window.defaultProps = {
   lastWindow: true,
   closed: false,
   onClosing: function onClosing() {},
-  onPositionChanged: function onPositionChanged() {},
+  onPositionChange: function onPositionChange() {},
   onContentSizeChanged: function onContentSizeChanged() {}
 };
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@ class Example extends Component {
     return (
       <App>
         <Window title="Example" height={300} width={300} menuBar={false}>
-          <Button stretchy={false} onClicked={() => console.log('Hello')}>
+          <Button stretchy={false} onClick={() => console.log('Hello')}>
             Button
           </Button>
         </Window>

--- a/docs/component_APIs/button.md
+++ b/docs/component_APIs/button.md
@@ -29,7 +29,7 @@ render(<Example />);
 - [children](#children)
 - [enabled](#enabled)
 - [visible](#visible)
-- [onClicked](#onClicked)
+- [onClick](#onClick)
 
 ## Reference
 
@@ -57,7 +57,7 @@ Whether the button can be seen.
 | --- | --- |
 | bool | No |
 
-### onClicked
+### onClick
 
 Called when the button is clicked.
 

--- a/docs/component_APIs/color_button.md
+++ b/docs/component_APIs/color_button.md
@@ -25,7 +25,7 @@ render(<Example />);
 ## Props
 
 - [color](#color)
-- [onChanged](#onChanged)
+- [onChange](#onChange)
 
 ## Reference
 
@@ -44,7 +44,7 @@ A full list of names can be found [here](https://www.w3schools.com/colors/colors
 | --- | --- |
 | string | No |
 
-### onClicked
+### onClick
 
 Called when the color is changed for the ColorButton. The current color is passed as an object of RGBA.
 

--- a/docs/component_APIs/menu_item.md
+++ b/docs/component_APIs/menu_item.md
@@ -28,7 +28,7 @@ render(<Example />);
 - [type](#type)
 - [children](#children)
 - [checked](#checked)
-- [onClicked](#onClicked)
+- [onClick](#onClick)
 
 ## Reference
 
@@ -63,7 +63,7 @@ If the type is `Check`, then set whether it is checked or not.
 | --- | --- |
 | bool | No |
 
-### onClicked
+### onClick
 
 Called when the menu item is clicked. If the type is `Check`, then it passes whether it is checked as an argument.
 

--- a/docs/component_APIs/picker.md
+++ b/docs/component_APIs/picker.md
@@ -84,7 +84,7 @@ When a *non-editable* Picker is changed. The current selection is passed as an a
 | --- | --- | --- |
 | function(selection) | No | No |
 
-### onChanged
+### onChange
 
 When an *editable* Picker is changed. The current text is passed as an argument.
 

--- a/docs/component_APIs/slider.md
+++ b/docs/component_APIs/slider.md
@@ -27,7 +27,7 @@ render(<Example />);
 - [enabled](#enabled)
 - [visible](#visible)
 - [value](#value)
-- [onChanged](#onChanged)
+- [onChange](#onChange)
 
 ## Reference
 
@@ -55,7 +55,7 @@ The current value of the Slider (0-100).
 | --- | --- |
 | number | No |
 
-### onChanged
+### onChange
 
 Called when the value of the slider is changed. The current value is passed as an argument.
 

--- a/docs/component_APIs/spinbox.md
+++ b/docs/component_APIs/spinbox.md
@@ -27,7 +27,7 @@ render(<Example />);
 - [enabled](#enabled)
 - [visible](#visible)
 - [value](#value)
-- [onChanged](#onChanged)
+- [onChange](#onChange)
 
 ## Reference
 
@@ -55,7 +55,7 @@ What the value of the Spinbox is set to.
 | --- | --- |
 | number | No |
 
-### onChanged
+### onChange
 
 When the Spinbox value is changed. The current value is passed as a parameter.
 

--- a/docs/component_APIs/textinput.md
+++ b/docs/component_APIs/textinput.md
@@ -30,7 +30,7 @@ render(<Example />);
 - [readOnly](#readOnly)
 - [secure](#secure)
 - [multiline](#multiline)
-- [onChanged](#onChanged)
+- [onChange](#onChange)
 
 ## Reference
 
@@ -82,7 +82,7 @@ Whether multiple lines can be inputted into the TextInput.
 | --- | --- |
 | bool | No |
 
-### onChanged
+### onChange
 
 Called when the TextInput text is changed. The new text is passed as an argument.
 

--- a/docs/component_APIs/window.md
+++ b/docs/component_APIs/window.md
@@ -34,7 +34,7 @@ render(<Example />);
 - [lastWindow](#lastWindow)
 - [closed](#closed)
 - [onClosing](#onClosing)
-- [onPositionChanged](#onPositionChanged)
+- [onPositionChange](#onPositionChange)
 - [onContentSizeChanged](#onContentSizeChanged)
 
 ## Reference
@@ -119,7 +119,7 @@ Called when the window is closed.
 | --- | --- |
 | function() | No |
 
-### onPositionChanged
+### onPositionChange
 
 Called when the window position is changed. The new position is passed as an argument, in an object.
 

--- a/docs/js_example.js
+++ b/docs/js_example.js
@@ -7,7 +7,7 @@ class Example extends Component {
     return (
       <App>
         <Window title="Example" height={300} width={300} menuBar={false}>
-          <Button stretchy={false} onClicked={() => console.log('Hello')}>
+          <Button stretchy={false} onClick={() => console.log('Hello')}>
             Button
           </Button>
         </Window>

--- a/docs/methods/dialog.md
+++ b/docs/methods/dialog.md
@@ -12,7 +12,7 @@ class Example extends Component {
     return (
       <App>
         <Window title="Example" size={{w: 500, h: 500}}>
-            <TextInput onChanged={() => Dialog('Error', {title: "Message"})}/>
+            <TextInput onChange={() => Dialog('Error', {title: "Message"})}/>
         </Window>
       </App>
     );

--- a/examples/notes.js
+++ b/examples/notes.js
@@ -21,12 +21,12 @@ class Example extends Component {
     return (
       <App>
         <Menu label="File">
-            <Menu.Item type="Item" onClicked={() => this.open()}>Open</Menu.Item>
-            <Menu.Item type="Item" onClicked={() => this.save()}>Save</Menu.Item>
+            <Menu.Item type="Item" onClick={() => this.open()}>Open</Menu.Item>
+            <Menu.Item type="Item" onClick={() => this.save()}>Save</Menu.Item>
         </Menu>
         <Window title="Notes" size={{w: 500, h: 500}}>
             <Box>
-                <TextInput onChanged={text => this.setState({text})} multiline={true}>{this.state.text}</TextInput>
+                <TextInput onChange={text => this.setState({text})} multiline={true}>{this.state.text}</TextInput>
             </Box>
         </Window>
       </App>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -6,7 +6,7 @@ import libui from 'libui-node';
 import PropTypes from 'prop-types';
 
 class Button extends DesktopComponent {
-  eventParameter = { onClicked: 'text' };
+  eventParameter = { onClick: 'text' };
   childName = 'text';
 
   constructor(root, props) {
@@ -27,7 +27,7 @@ class Button extends DesktopComponent {
 Button.PropTypes = {
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
-  onClicked: PropTypes.func,
+  onClick: PropTypes.func,
   children: PropTypes.string,
   ...universalPropTypes,
 };
@@ -35,7 +35,7 @@ Button.PropTypes = {
 Button.defaultProps = {
   enabled: true,
   visible: true,
-  onClicked: () => {},
+  onClick: () => {},
   children: '',
   ...universalDefaultProps,
 };

--- a/src/components/ColorButton.js
+++ b/src/components/ColorButton.js
@@ -7,7 +7,7 @@ import Color from 'color';
 import PropTypes from 'prop-types';
 
 class ColorButton extends DesktopComponent {
-  eventParameter = { onChanged: 'color' };
+  eventParameter = { onChange: 'color' };
 
   constructor(root, props) {
     super(root, props);
@@ -91,13 +91,13 @@ class ColorButton extends DesktopComponent {
 
 ColorButton.PropTypes = {
   color: PropTypes.string,
-  onChanged: PropTypes.func,
+  onChange: PropTypes.func,
   ...universalPropTypes,
 };
 
 ColorButton.defaultProps = {
   color: 'black',
-  onChanged: () => {},
+  onChange: () => {},
   ...universalDefaultProps,
 };
 

--- a/src/components/EditableCombobox.js
+++ b/src/components/EditableCombobox.js
@@ -6,7 +6,7 @@ import libui from 'libui-node';
 import PropTypes from 'prop-types';
 
 class EditableCombobox extends DesktopComponent {
-  eventParameter = { onChanged: 'text' };
+  eventParameter = { onChange: 'text' };
 
   constructor(root, props) {
     super(root, props);
@@ -28,7 +28,7 @@ EditableCombobox.PropTypes = {
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   text: PropTypes.string,
-  onChanged: PropTypes.func,
+  onChange: PropTypes.func,
   ...universalPropTypes,
 };
 
@@ -36,7 +36,7 @@ EditableCombobox.defaultProps = {
   enabled: true,
   visible: true,
   text: '',
-  onChanged: () => {},
+  onChange: () => {},
   ...universalDefaultProps,
 };
 

--- a/src/components/Entry.js
+++ b/src/components/Entry.js
@@ -6,7 +6,7 @@ import libui from 'libui-node';
 import PropTypes from 'prop-types';
 
 class Entry extends DesktopComponent {
-  eventParameter = { onChanged: 'text' };
+  eventParameter = { onChange: 'text' };
   childName = 'text';
 
   constructor(root, props) {
@@ -28,7 +28,7 @@ Entry.PropTypes = {
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   readOnly: PropTypes.bool,
-  onChanged: PropTypes.func,
+  onChange: PropTypes.func,
   children: PropTypes.string,
   ...universalPropTypes,
 };
@@ -37,7 +37,7 @@ Entry.defaultProps = {
   enabled: true,
   visible: true,
   readOnly: false,
-  onChanged: () => {},
+  onChange: () => {},
   children: '',
   ...universalDefaultProps,
 };

--- a/src/components/FontButton.js
+++ b/src/components/FontButton.js
@@ -6,7 +6,7 @@ import libui from 'libui-node';
 import PropTypes from 'prop-types';
 
 class FontButton extends DesktopComponent {
-  eventParameter = { onChanged: () => this.element.getFont() };
+  eventParameter = { onChange: () => this.element.getFont() };
 
   constructor(root, props) {
     super(root, props);
@@ -24,12 +24,12 @@ class FontButton extends DesktopComponent {
 }
 
 FontButton.PropTypes = {
-  onChanged: PropTypes.func,
+  onChange: PropTypes.func,
   ...universalPropTypes,
 };
 
 FontButton.defaultProps = {
-  onChanged: () => {},
+  onChange: () => {},
   ...universalDefaultProps,
 };
 

--- a/src/components/MenuBar.js
+++ b/src/components/MenuBar.js
@@ -32,7 +32,7 @@ MenuBar.defaultProps = {
 };
 
 MenuBar.Item = class Item extends DesktopComponent {
-  eventParameter = { onClicked: 'checked' };
+  eventParameter = { onClick: 'checked' };
   constructor(root, props) {
     super(root, props);
     this.root = root;
@@ -64,7 +64,7 @@ MenuBar.Item.PropTypes = {
     'Separator',
     'Item',
   ]),
-  onClicked: PropTypes.func,
+  onClick: PropTypes.func,
   ...universalPropTypes,
 };
 
@@ -72,7 +72,7 @@ MenuBar.Item.defaultProps = {
   children: '',
   checked: false,
   type: 'Item',
-  onClicked: () => {},
+  onClick: () => {},
   ...universalDefaultProps,
 };
 

--- a/src/components/MultilineEntry.js
+++ b/src/components/MultilineEntry.js
@@ -6,7 +6,7 @@ import libui from 'libui-node';
 import PropTypes from 'prop-types';
 
 class MultilineEntry extends DesktopComponent {
-  eventParameter = { onChanged: 'text' };
+  eventParameter = { onChange: 'text' };
   childName = 'text';
 
   constructor(root, props) {
@@ -28,7 +28,7 @@ MultilineEntry.PropTypes = {
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   readOnly: PropTypes.bool,
-  onChanged: PropTypes.func,
+  onChange: PropTypes.func,
   children: PropTypes.string,
   ...universalPropTypes,
 };
@@ -37,7 +37,7 @@ MultilineEntry.defaultProps = {
   enabled: true,
   visible: true,
   readOnly: false,
-  onChanged: () => {},
+  onChange: () => {},
   children: '',
   ...universalDefaultProps,
 };

--- a/src/components/PasswordEntry.js
+++ b/src/components/PasswordEntry.js
@@ -6,7 +6,7 @@ import libui from 'libui-node';
 import PropTypes from 'prop-types';
 
 class PasswordEntry extends DesktopComponent {
-  eventParameter = { onChanged: 'text' };
+  eventParameter = { onChange: 'text' };
   childName = 'text';
 
   constructor(root, props) {
@@ -28,7 +28,7 @@ PasswordEntry.PropTypes = {
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   readOnly: PropTypes.bool,
-  onChanged: PropTypes.func,
+  onChange: PropTypes.func,
   children: PropTypes.string,
   ...universalPropTypes,
 };
@@ -37,7 +37,7 @@ PasswordEntry.defaultProps = {
   enabled: true,
   visible: true,
   readOnly: false,
-  onChanged: () => {},
+  onChange: () => {},
   children: '',
   ...universalDefaultProps,
 };

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -6,7 +6,7 @@ import libui from 'libui-node';
 import PropTypes from 'prop-types';
 
 class Slider extends DesktopComponent {
-  eventParameter = { onChanged: 'value' };
+  eventParameter = { onChange: 'value' };
 
   constructor(root, props) {
     super(root, props);
@@ -27,7 +27,7 @@ Slider.PropTypes = {
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   value: PropTypes.number,
-  onChanged: PropTypes.func,
+  onChange: PropTypes.func,
   ...universalPropTypes,
 };
 
@@ -35,7 +35,7 @@ Slider.defaultProps = {
   enabled: true,
   visible: true,
   value: 0,
-  onChanged: () => {},
+  onChange: () => {},
   ...universalDefaultProps,
 };
 

--- a/src/components/Spinbox.js
+++ b/src/components/Spinbox.js
@@ -6,7 +6,7 @@ import libui from 'libui-node';
 import PropTypes from 'prop-types';
 
 class Spinbox extends DesktopComponent {
-  eventParameter = { onChanged: 'value' };
+  eventParameter = { onChange: 'value' };
 
   constructor(root, props) {
     super(root, props);
@@ -27,7 +27,7 @@ Spinbox.PropTypes = {
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   value: PropTypes.number,
-  onChanged: PropTypes.func,
+  onChange: PropTypes.func,
   ...universalPropTypes,
 };
 
@@ -35,7 +35,7 @@ Spinbox.defaultProps = {
   enabled: true,
   visible: true,
   value: 0,
-  onChanged: () => {},
+  onChange: () => {},
   ...universalDefaultProps,
 };
 

--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -80,8 +80,8 @@ class Window extends DesktopComponent {
         this.element.center();
       }
 
-      this.element.onPositionChanged(() => {
-        this.props.onPositionChanged({
+      this.element.onPositionChange(() => {
+        this.props.onPositionChange({
           x: this.element.position.x,
           y: this.element.position.y,
         });
@@ -117,7 +117,7 @@ Window.PropTypes = {
   lastWindow: PropTypes.bool,
   closed: PropTypes.bool,
   onClosing: PropTypes.func,
-  onPositionChanged: PropTypes.func,
+  onPositionChange: PropTypes.func,
   onContentSizeChanged: PropTypes.func,
 };
 
@@ -139,7 +139,7 @@ Window.defaultProps = {
   lastWindow: true,
   closed: false,
   onClosing: () => {},
-  onPositionChanged: () => {},
+  onPositionChange: () => {},
   onContentSizeChanged: () => {},
 };
 

--- a/test_libui.js
+++ b/test_libui.js
@@ -4,7 +4,7 @@ libui.Ui.init();
 
 var win = new libui.UiWindow('Example window', 640, 480, true);
 var font = new libui.UiFontButton();
-font.onChanged(function() {
+font.onChange(function() {
   console.log(font.getFont());
 });
 win.setChild(font);


### PR DESCRIPTION
In React, events are typically called onChange and onClick rather than onChanged and onClicked. Response to `gaearon` issue - Use React event naming conventions #9
