### PR TITLE
Using binaries directly in package.json

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ And then add the following to your `package.json`:
 
 ```
   "scripts": {
-    "start": "node_modules/.bin/babel-node index.js"
+    "start": "babel-node index.js"
   }
 ```
 


### PR DESCRIPTION
Binaries on node_modules are already on `PATH` in package.json