### PR TITLE
Add some Linux Pre-Req install steps

### DIFF
--- a/LinuxReadMe.md
+++ b/LinuxReadMe.md
@@ -11,6 +11,8 @@ sudo apt-get install build-essential libgtk-3-dev nodejs
 ```console
 sudo apt-get remove node-builtins node-husl node-libravatar node-mirror node-po2json node-imagemagick node-util node-chrono node-wordwrap node-growl node-object-key node-get node-mustache node-requirejs node-sphericalmercator node-tunein node-underscore node-punnycode node-queue-asynce node-cssom node-highlight.js node-iscroll node-jsv node-marked node-optimist node-websocket node-d3-format node-htmlparser node-jquery-ui node-modestmaps node-xtrem node-create-hmac node-url nodejs-dev node-htmtl2canvas node-rollup-plugin-string node-assert-plus node-flashproxy node-hash.js
 ```
-
+```console
+npm -g remove node-gyp
+```
 ### Tested
 * Xubuntu, Kubuntu 17.10

--- a/LinuxReadMe.md
+++ b/LinuxReadMe.md
@@ -1,0 +1,16 @@
+# Prerequisite For Linux Installations
+
+## Install what is needed.
+
+`Debian based OS, such as Ubuntu and Linux Mint.`
+```console
+sudo apt-get install build-essential libgtk-3-dev nodejs
+```
+
+## Remove what isn't needed.
+```console
+sudo apt-get remove node-builtins node-husl node-libravatar node-mirror node-po2json node-imagemagick node-util node-chrono node-wordwrap node-growl node-object-key node-get node-mustache node-requirejs node-sphericalmercator node-tunein node-underscore node-punnycode node-queue-asynce node-cssom node-highlight.js node-iscroll node-jsv node-marked node-optimist node-websocket node-d3-format node-htmlparser node-jquery-ui node-modestmaps node-xtrem node-create-hmac node-url nodejs-dev node-htmtl2canvas node-rollup-plugin-string node-assert-plus node-flashproxy node-hash.js
+```
+
+### Tested
+* Xubuntu, Kubuntu 17.10

--- a/README.md
+++ b/README.md
@@ -41,4 +41,6 @@ All contributions are welcome. Just make a PR. Below is a list of general improv
 - Make packaging easier
 - Make creating a new app easier (something similar to `create-react-app`)
 
+#### [Linux Prerequisites](./LinuxReadMe.md)
+
 <a href="https://www.keycdn.com/"><sub><sup>Accelerated by KeyCDN</sup></sub></a>


### PR DESCRIPTION
Tried to create some install steps for Linux users. The steps include removing global nodejs conflicts installed from the package manager, removing global nodejs conflicts from using npm i -g, installing build-essential and libgtk-3-dev dependencies from package manager.

Steps only apply to Debian based flavours and would need to be altered for Arch based, Slack Based and RPM based flavours.