### PR TITLE
Refactor components props

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -25,19 +25,19 @@ class Button extends DesktopComponent {
 }
 
 Button.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   onClick: PropTypes.func,
   children: PropTypes.string,
-  ...universalPropTypes,
 };
 
 Button.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   onClick: () => {},
   children: '',
-  ...universalDefaultProps,
 };
 
 export default Button;

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -25,21 +25,21 @@ class Checkbox extends DesktopComponent {
 }
 
 Checkbox.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   checked: PropTypes.bool,
   onToggle: PropTypes.func,
   children: PropTypes.string,
-  ...universalPropTypes,
 };
 
 Checkbox.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   checked: false,
   onToggle: () => {},
   children: '',
-  ...universalDefaultProps,
 };
 
 export default Checkbox;

--- a/src/components/ColorButton.js
+++ b/src/components/ColorButton.js
@@ -90,15 +90,15 @@ class ColorButton extends DesktopComponent {
 }
 
 ColorButton.PropTypes = {
+  ...universalPropTypes,
   color: PropTypes.string,
   onChange: PropTypes.func,
-  ...universalPropTypes,
 };
 
 ColorButton.defaultProps = {
+  ...universalDefaultProps,
   color: 'black',
   onChange: () => {},
-  ...universalDefaultProps,
 };
 
 export default ColorButton;

--- a/src/components/Combobox.js
+++ b/src/components/Combobox.js
@@ -25,19 +25,19 @@ class Combobox extends DesktopComponent {
 }
 
 Combobox.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   selected: PropTypes.number,
   onSelect: PropTypes.func,
-  ...universalPropTypes,
 };
 
 Combobox.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   selected: -1,
   onSelect: () => {},
-  ...universalDefaultProps,
 };
 
 Combobox.Item = class Item extends DesktopComponent {

--- a/src/components/EditableCombobox.js
+++ b/src/components/EditableCombobox.js
@@ -25,19 +25,19 @@ class EditableCombobox extends DesktopComponent {
 }
 
 EditableCombobox.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   text: PropTypes.string,
   onChange: PropTypes.func,
-  ...universalPropTypes,
 };
 
 EditableCombobox.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   text: '',
   onChange: () => {},
-  ...universalDefaultProps,
 };
 
 EditableCombobox.Item = class Item extends DesktopComponent {

--- a/src/components/Entry.js
+++ b/src/components/Entry.js
@@ -25,21 +25,21 @@ class Entry extends DesktopComponent {
 }
 
 Entry.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   readOnly: PropTypes.bool,
   onChange: PropTypes.func,
   children: PropTypes.string,
-  ...universalPropTypes,
 };
 
 Entry.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   readOnly: false,
   onChange: () => {},
   children: '',
-  ...universalDefaultProps,
 };
 
 export default Entry;

--- a/src/components/FontButton.js
+++ b/src/components/FontButton.js
@@ -24,13 +24,13 @@ class FontButton extends DesktopComponent {
 }
 
 FontButton.PropTypes = {
-  onChange: PropTypes.func,
   ...universalPropTypes,
+  onChange: PropTypes.func,
 };
 
 FontButton.defaultProps = {
-  onChange: () => {},
   ...universalDefaultProps,
+  onChange: () => {},
 };
 
 export default FontButton;

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -22,17 +22,17 @@ class Form extends DesktopComponent {
 }
 
 Form.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   padded: PropTypes.bool,
-  ...universalPropTypes,
 };
 
 Form.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   padded: false,
-  ...universalDefaultProps,
 };
 
 export default Form;

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -22,17 +22,17 @@ class Grid extends DesktopComponent {
 }
 
 Grid.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   padded: PropTypes.bool,
-  ...universalPropTypes,
 };
 
 Grid.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   padded: false,
-  ...universalDefaultProps,
 };
 
 export default Grid;

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -22,19 +22,19 @@ class Group extends DesktopComponent {
 }
 
 Group.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   margined: PropTypes.bool,
   title: PropTypes.string,
-  ...universalPropTypes,
 };
 
 Group.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   margined: false,
   title: '',
-  ...universalDefaultProps,
 };
 
 export default Group;

--- a/src/components/HorizontalBox.js
+++ b/src/components/HorizontalBox.js
@@ -22,17 +22,17 @@ class HorizontalBox extends DesktopComponent {
 }
 
 HorizontalBox.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   padded: PropTypes.bool,
-  ...universalPropTypes,
 };
 
 HorizontalBox.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   padded: false,
-  ...universalDefaultProps,
 };
 
 export default HorizontalBox;

--- a/src/components/HorizontalSeparator.js
+++ b/src/components/HorizontalSeparator.js
@@ -22,15 +22,15 @@ class HorizontalSeparator extends DesktopComponent {
 }
 
 HorizontalSeparator.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
-  ...universalPropTypes,
 };
 
 HorizontalSeparator.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
-  ...universalDefaultProps,
 };
 
 export default HorizontalSeparator;

--- a/src/components/MenuBar.js
+++ b/src/components/MenuBar.js
@@ -22,13 +22,13 @@ class MenuBar extends DesktopComponent {
 }
 
 MenuBar.PropTypes = {
-  label: PropTypes.string,
   ...universalPropTypes,
+  label: PropTypes.string,
 };
 
 MenuBar.defaultProps = {
-  label: '',
   ...universalDefaultProps,
+  label: '',
 };
 
 MenuBar.Item = class Item extends DesktopComponent {

--- a/src/components/MultilineEntry.js
+++ b/src/components/MultilineEntry.js
@@ -25,21 +25,21 @@ class MultilineEntry extends DesktopComponent {
 }
 
 MultilineEntry.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   readOnly: PropTypes.bool,
   onChange: PropTypes.func,
   children: PropTypes.string,
-  ...universalPropTypes,
 };
 
 MultilineEntry.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   readOnly: false,
   onChange: () => {},
   children: '',
-  ...universalDefaultProps,
 };
 
 export default MultilineEntry;

--- a/src/components/PasswordEntry.js
+++ b/src/components/PasswordEntry.js
@@ -25,21 +25,21 @@ class PasswordEntry extends DesktopComponent {
 }
 
 PasswordEntry.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   readOnly: PropTypes.bool,
   onChange: PropTypes.func,
   children: PropTypes.string,
-  ...universalPropTypes,
 };
 
 PasswordEntry.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   readOnly: false,
   onChange: () => {},
   children: '',
-  ...universalDefaultProps,
 };
 
 export default PasswordEntry;

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -22,17 +22,17 @@ class ProgressBar extends DesktopComponent {
 }
 
 ProgressBar.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   value: PropTypes.number,
-  ...universalPropTypes,
 };
 
 ProgressBar.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   value: 0,
-  ...universalDefaultProps,
 };
 
 export default ProgressBar;

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -25,19 +25,19 @@ class RadioButton extends DesktopComponent {
 }
 
 RadioButton.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   selected: PropTypes.number,
   onSelect: PropTypes.func,
-  ...universalPropTypes,
 };
 
 RadioButton.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   selected: -1,
   onSelect: () => {},
-  ...universalDefaultProps,
 };
 
 RadioButton.Item = class Item extends DesktopComponent {

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -24,19 +24,19 @@ class Slider extends DesktopComponent {
 }
 
 Slider.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   value: PropTypes.number,
   onChange: PropTypes.func,
-  ...universalPropTypes,
 };
 
 Slider.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   value: 0,
   onChange: () => {},
-  ...universalDefaultProps,
 };
 
 export default Slider;

--- a/src/components/Spinbox.js
+++ b/src/components/Spinbox.js
@@ -24,19 +24,19 @@ class Spinbox extends DesktopComponent {
 }
 
 Spinbox.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   value: PropTypes.number,
   onChange: PropTypes.func,
-  ...universalPropTypes,
 };
 
 Spinbox.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   value: 0,
   onChange: () => {},
-  ...universalDefaultProps,
 };
 
 export default Spinbox;

--- a/src/components/Tab.js
+++ b/src/components/Tab.js
@@ -22,15 +22,15 @@ class Tab extends DesktopComponent {
 }
 
 Tab.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
-  ...universalPropTypes,
 };
 
 Tab.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
-  ...universalDefaultProps,
 };
 
 export default Tab;

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -24,17 +24,17 @@ class Text extends DesktopComponent {
 }
 
 Text.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   children: PropTypes.string,
-  ...universalPropTypes,
 };
 
 Text.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   children: '',
-  ...universalDefaultProps,
 };
 
 export default Text;

--- a/src/components/VerticalBox.js
+++ b/src/components/VerticalBox.js
@@ -22,17 +22,17 @@ class VerticalBox extends DesktopComponent {
 }
 
 VerticalBox.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
   padded: PropTypes.bool,
-  ...universalPropTypes,
 };
 
 VerticalBox.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
   padded: false,
-  ...universalDefaultProps,
 };
 
 export default VerticalBox;

--- a/src/components/VerticalSeparator.js
+++ b/src/components/VerticalSeparator.js
@@ -22,15 +22,15 @@ class VerticalSeparator extends DesktopComponent {
 }
 
 VerticalSeparator.PropTypes = {
+  ...universalPropTypes,
   enabled: PropTypes.bool,
   visible: PropTypes.bool,
-  ...universalPropTypes,
 };
 
 VerticalSeparator.defaultProps = {
+  ...universalDefaultProps,
   enabled: true,
   visible: true,
-  ...universalDefaultProps,
 };
 
 export default VerticalSeparator;


### PR DESCRIPTION
The goal of this PR is to improve the way we _compose_ `universalDefaultProps` and `universalPropTypes`.

By moving the destructuring statement on top of the object we ensure that any of the properties listed will not be overwritten by the defaults.

For example

```js
var foo = {
  name: 'proton'
};

var barNotOk = {
  name: 'this will not work',
  ...foo
};

var barOk = {
  ...foo,
  name: 'this will work'
};

console.log(barNotOk); // { name: 'proton' }
console.log(barOk); // { name: 'this will work' }
```