### PR TITLE
Make python hello-world example comparable to proton example

### DIFF
--- a/docs/python_example.py
+++ b/docs/python_example.py
@@ -1,33 +1,15 @@
 import sys
-from PyQt5.QtWidgets import (QWidget, QToolTip, 
-    QPushButton, QApplication)
-from PyQt5.QtGui import QFont    
+from PyQt5 import QtWidgets
 
-
-class Example(QWidget):
-    
+class Example(QtWidgets.QWidget):
     def __init__(self):
         super().__init__()
-        
-        self.initUI()
-
-    def print_hello(self):
-        print("Hello")
-        
-        
-    def initUI(self):
-        btn = QPushButton('Button', self)
-        btn.clicked.connect(self.print_hello)
-        btn.resize(btn.sizeHint())
-        btn.move(50, 50)       
-        
+        btn = QtWidgets.QPushButton('Button', self)
+        btn.clicked.connect(lambda: print('hello'))
         self.setGeometry(300, 300, 300, 200)
-        self.setWindowTitle('Example')    
+        self.setWindowTitle('Example')
         self.show()
-        
-        
-if __name__ == '__main__':
-    
-    app = QApplication(sys.argv)
-    ex = Example()
-    sys.exit(app.exec_())
+
+app = QtWidgets.QApplication([])
+ex = Example()
+sys.exit(app.exec_())


### PR DESCRIPTION
I removed the odd double-line spacing in the class between `print_hello()` and `initUI()`, and also refactored out the call to `initUI` because it typically isn't used in smaller apps.  I also reduced outer-scope line gaps to single-space, rather than double space because this is what the proton example uses.

Is the `btn.move(50, 50)` necessary?  The proton example code doesn't have this, but it might use a default style that produces a similar effect? Dunno.  If you want it back in I will add it.

Proton Native looks really neat, good job!