### PR TITLE
Devtools

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,6 +5,7 @@ import DesktopComponent, {
 } from './DesktopComponent';
 
 import PropTypes from 'prop-types';
+import { disconnectDevtools } from '../devtools';
 
 class App extends DesktopComponent {
   constructor(root, props) {
@@ -27,6 +28,7 @@ class App extends DesktopComponent {
   render() {
     libui.Ui.onShouldQuit(() => {
       this.props.onShouldQuit();
+      disconnectDevtools();
       libui.stopLoop();
     });
     this.renderChildNode(this);

--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -4,6 +4,7 @@ import DesktopComponent, {
 } from './DesktopComponent';
 import libui from 'libui-node';
 import PropTypes from 'prop-types';
+import { disconnectDevtools } from '../devtools';
 
 var CURRENT_WINDOW = null;
 
@@ -65,6 +66,7 @@ class Window extends DesktopComponent {
         this.props.onClose();
         this.element.close();
         if (this.props.lastWindow) {
+          disconnectDevtools();
           libui.stopLoop();
         }
       });

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -1,0 +1,41 @@
+let connectToDevTools, WebSocket;
+
+// from jaredhanson/node-parent-require
+const prequire = function(id) {
+  for (let parent = module.parent; parent; parent = parent.parent) {
+    try {
+      return parent.require(id);
+    } catch (e) {}
+  }
+  throw new Error("Cannot find module '" + id + "' from parent");
+};
+
+try {
+  global.window = global;
+  WebSocket = prequire('ws');
+  connectToDevTools = prequire('react-devtools-core').connectToDevTools;
+} catch (e) {}
+
+let ws;
+
+function connect(reconciler) {
+  if (connectToDevTools && WebSocket) {
+    ws = new WebSocket('ws://localhost:8097');
+    connectToDevTools({ websocket: ws });
+    reconciler.injectIntoDevTools({
+      bundleType: 1,
+      version: '0.1.0',
+      rendererPackageName: 'custom-renderer',
+      findHostInstanceByFiber: reconciler.findHostInstance,
+    });
+  }
+}
+
+function disconnectDevtools() {
+  if (ws) {
+    ws.close();
+  }
+}
+
+export default connect;
+export { disconnectDevtools };

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -10,15 +10,17 @@ const prequire = function(id) {
   throw new Error("Cannot find module '" + id + "' from parent");
 };
 
-try {
-  global.window = global;
-  WebSocket = prequire('ws');
-  connectToDevTools = prequire('react-devtools-core').connectToDevTools;
-} catch (e) {}
+if (process.env.NODE_ENV !== 'production') {
+  try {
+    global.window = global;
+    WebSocket = prequire('ws');
+    connectToDevTools = prequire('react-devtools-core').connectToDevTools;
+  } catch (e) {}
+}
 
 let ws;
 
-function connect(reconciler) {
+function connectDevtools(reconciler) {
   if (connectToDevTools && WebSocket) {
     ws = new WebSocket('ws://localhost:8097');
     connectToDevTools({ websocket: ws });
@@ -32,10 +34,13 @@ function connect(reconciler) {
 }
 
 function disconnectDevtools() {
-  if (ws) {
+  if (
+    ws &&
+    WebSocket &&
+    (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)
+  ) {
     ws.close();
   }
 }
 
-export default connect;
-export { disconnectDevtools };
+export { connectDevtools, disconnectDevtools };

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,25 +1,44 @@
 import { createElement } from '../utils/createElement';
 import DesktopRenderer from '../reconciler/';
 
+let connectToDevTools = () => {};
+
+// from jaredhanson/node-parent-require
+const prequire = function(id) {
+  for (let parent = module.parent; parent; parent = parent.parent) {
+    try {
+      return parent.require(id);
+    } catch (e) {}
+  }
+  throw new Error("Cannot find module '" + id + "' from parent");
+};
+
+try {
+  global.window = global;
+  global.window.WebSocket = prequire('ws');
+  connectToDevTools = prequire('react-devtools-core').connectToDevTools;
+} catch (e) {}
+
 export let ROOT_NODE = {};
 
 // Renders the input component
 function render(element) {
-  ROOT_NODE = createElement('ROOT');
-  const container = ROOT_NODE;
+  connectToDevTools();
+  DesktopRenderer.injectIntoDevTools({
+    bundleType: 1,
+    version: '0.1.0',
+    rendererPackageName: 'custom-renderer',
+    findHostInstanceByFiber: DesktopRenderer.findHostInstance,
+  });
 
+  const container = ROOT_NODE;
+  ROOT_NODE = createElement('ROOT');
   // Returns the current fiber (flushed fiber)
   const node = DesktopRenderer.createContainer(ROOT_NODE);
 
   // Schedules a top level update with current fiber and a priority level (depending upon the context)
   DesktopRenderer.updateContainer(element, node, null);
   ROOT_NODE.render();
-  // DesktopRenderer.injectIntoDevTools({
-  //   bundleType: 1,
-  //   version: '0.1.0',
-  //   rendererPackageName: 'custom-renderer',
-  //   findHostInstanceByFiber: DesktopRenderer.findHostInstance
-  // })
 }
 
 export default render;

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,38 +1,16 @@
 import { createElement } from '../utils/createElement';
 import DesktopRenderer from '../reconciler/';
-
-let connectToDevTools = () => {};
-
-// from jaredhanson/node-parent-require
-const prequire = function(id) {
-  for (let parent = module.parent; parent; parent = parent.parent) {
-    try {
-      return parent.require(id);
-    } catch (e) {}
-  }
-  throw new Error("Cannot find module '" + id + "' from parent");
-};
-
-try {
-  global.window = global;
-  global.window.WebSocket = prequire('ws');
-  connectToDevTools = prequire('react-devtools-core').connectToDevTools;
-} catch (e) {}
+import connectDevtools from '../devtools';
 
 export let ROOT_NODE = {};
 
 // Renders the input component
 function render(element) {
-  connectToDevTools();
-  DesktopRenderer.injectIntoDevTools({
-    bundleType: 1,
-    version: '0.1.0',
-    rendererPackageName: 'custom-renderer',
-    findHostInstanceByFiber: DesktopRenderer.findHostInstance,
-  });
+  connectDevtools(DesktopRenderer);
 
-  const container = ROOT_NODE;
   ROOT_NODE = createElement('ROOT');
+  const container = ROOT_NODE;
+
   // Returns the current fiber (flushed fiber)
   const node = DesktopRenderer.createContainer(ROOT_NODE);
 

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,6 +1,6 @@
 import { createElement } from '../utils/createElement';
 import DesktopRenderer from '../reconciler/';
-import connectDevtools from '../devtools';
+import { connectDevtools } from '../devtools';
 
 export let ROOT_NODE = {};
 


### PR DESCRIPTION
Makes react devtools work.

![bildschirmfoto 2018-05-05 um 18 32 07](https://user-images.githubusercontent.com/4586894/39665912-af460a98-509b-11e8-9eda-9e3ac188be99.png)

Will be used if the `react-devtools-core` is installed locally (either directly or via `react-devtools`). Not sure where to mention this in the docs.