### PR TITLE
Bump version of libui-node to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "color": "^3.0.0",
     "fbjs": "^0.8.16",
-    "libui-node": "^0.1.0",
+    "libui-node": "^0.2.0",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-reconciler": "^0.7.0",


### PR DESCRIPTION
I check Notepad and area example and seems all run fine.