### PR TITLE
Area fixup

### DIFF
--- a/docs/component_APIs/area.md
+++ b/docs/component_APIs/area.md
@@ -15,7 +15,13 @@ class Example extends Component {
       <App>
         <Window title="Example" size={{ w: 500, h: 500 }}>
           <Area stroke="red" strokeWidth="10">
-            <Area.Rectangle x="10" y="10" width="100" height="200" fill="blue" />
+            <Area.Rectangle
+              x="10"
+              y="10"
+              width="100"
+              height="200"
+              fill="blue"
+            />
           </Area>
         </Window>
       </App>
@@ -94,15 +100,15 @@ Called when the mouse leaves the area.
 Called when pressing a key.
 Return `true` to signal that this event got handled (always returning true will disable any menu accelerators).
 
-| **Type**                                                                        | **Required** |
-| ------------------------------------------------------------------------------- | ------------ |
-| function({key: string, extKey: number, modifierKey: number, modifiers: number}) | No           |
+| **Type**                                                                                 | **Required** |
+| ---------------------------------------------------------------------------------------- | ------------ |
+| function({key: string, extKey: string, modifierKey: string, modifiers: Array\<string\>}) | No           |
 
 ### onKeyDown
 
 Called when releasing a key.
 Return `true` to signal that this event got handled (always returning true will disable any menu accelerators).
 
-| **Type**                                                                        | **Required** |
-| ------------------------------------------------------------------------------- | ------------ |
-| function({key: string, extKey: number, modifierKey: number, modifiers: number}) | No           |
+| **Type**                                                                                 | **Required** |
+| ---------------------------------------------------------------------------------------- | ------------ |
+| function({key: string, extKey: string, modifierKey: string, modifiers: Array\<string\>}) | No           |

--- a/docs/component_APIs/area.md
+++ b/docs/component_APIs/area.md
@@ -73,11 +73,11 @@ Called when releasing a mouse button over the area.
 
 ### onMouseDown
 
-Called when pressing a mouse button over the area.
+Called when pressing a mouse button over the area. For a double click, the second click would fire an event with `count: 2`.
 
-| **Type**                                                                        | **Required** |
-| ------------------------------------------------------------------------------- | ------------ |
-| function({x: number, y: number, width: number, height: number, button: number}) | No           |
+| **Type**                                                                                       | **Required** |
+| ---------------------------------------------------------------------------------------------- | ------------ |
+| function({x: number, y: number, width: number, height: number, button: number, count: number}) | No           |
 
 ### onMouseEnter
 

--- a/examples/area.js
+++ b/examples/area.js
@@ -1,5 +1,15 @@
 import React, { Component } from 'react';
-import { render, Window, App, Box, Menu, Button, Slider, Area } from '../src/';
+import {
+  render,
+  Window,
+  App,
+  Box,
+  Menu,
+  Button,
+  Slider,
+  Area,
+  Text,
+} from '../src/';
 
 class Example extends Component {
   state = { bool: false, val: 40, dragging: false, pos: { x: 50, y: 220 } };
@@ -7,8 +17,9 @@ class Example extends Component {
   render() {
     return (
       <App>
-        <Window title="Test" size={{ w: 600, h: 600 }} margined={true}>
-          <Box>
+        <Window title="Test" size={{ w: 600, h: 650 }} margined={true}>
+          <Box padded>
+            <Text stretchy={false}>Try dragging the circle!</Text>
             <Area
               // onKeyUp={e => {
               //   console.log('up', e.key);

--- a/src/components/Area.js
+++ b/src/components/Area.js
@@ -339,11 +339,16 @@ class AreaComponent {
             p
           );
           if (process.platform === 'win32') {
-            mat.scale(xy.x, xy.y, scale[1], fallback(scale[2], scale[1]));
+            mat.scale(
+              xy.x,
+              xy.y,
+              Number(scale[1]),
+              fallback(scale[2], scale[1])
+            );
           } else {
             // https://github.com/andlabs/libui/issues/331:
             mat.translate(xy.x, xy.y);
-            mat.scale(0, 0, scale[1], fallback(scale[2], scale[1]));
+            mat.scale(0, 0, Number(scale[1]), fallback(scale[2], scale[1]));
             mat.translate(-xy.x, -xy.y);
           }
         }
@@ -399,25 +404,25 @@ class AreaComponent {
 
         switch (props.strokeLinecap) {
           case 'flat':
-            sp.cap = 0;
+            sp.cap = libui.lineCap.flat;
             break;
           case 'round':
-            sp.cap = 1;
+            sp.cap = libui.lineCap.round;
             break;
           case 'square':
-            sp.cap = 2;
+            sp.cap = libui.lineCap.square;
             break;
         }
 
         switch (props.strokeLinejoin) {
           case 'miter':
-            sp.join = 0;
+            sp.join = libui.lineJoin.miter;
             break;
           case 'round':
-            sp.join = 1;
+            sp.join = libui.lineJoin.round;
             break;
           case 'bevel':
-            sp.join = 2;
+            sp.join = libui.lineJoin.bevel;
             break;
         }
 
@@ -669,7 +674,9 @@ Area.Bezier.propTypes = {
 Area.Path = class Path extends AreaComponent {
   draw(area, p) {
     const path = new libui.UiDrawPath(
-      this.props.fillRule === 'evenodd' ? 1 : 0
+      this.props.fillRule === 'evenodd'
+        ? libui.fillMode.alternate
+        : libui.fillMode.winding
     );
     const commands = parseSVG(this.props.d);
     parseSVG.makeAbsolute(commands);

--- a/src/components/Area.js
+++ b/src/components/Area.js
@@ -25,7 +25,7 @@ class Area extends DesktopComponent {
       },
       (area, evt) => {
         const down = evt.getDown();
-        const up = 0; //evt.getUp();
+        const up = evt.getUp();
         if (up) {
           this.props.onMouseUp({
             x: evt.getX(),
@@ -148,7 +148,7 @@ function createBrush(color, alpha) {
     color.blue() / 255,
     color.alpha() * alpha
   );
-  brush.type = 0 /*uiDrawBrushTypeSolid*/;
+  brush.type = libui.brushType.solid;
 
   return brush;
 }
@@ -391,13 +391,13 @@ class AreaComponent {
 
         p.getContext().stroke(path, strokeBrush, sp);
 
-        //sp.free();
-        //strokBrush.free();
+        sp.free();
+        strokeBrush.free();
       }
 
       if (fillBrush) {
         p.getContext().fill(path, fillBrush);
-        //fillBrush.free();
+        fillBrush.free();
       }
 
       path.freePath();
@@ -467,7 +467,7 @@ Area.Rectangle = class Rectangle extends AreaComponent {
   }
 
   draw(area, p) {
-    const path = new libui.UiDrawPath(0 /*uiDrawFillModeWinding*/);
+    const path = new libui.UiDrawPath(libui.fillMode.winding);
     path.addRectangle(
       this.parseParent(this.props.x, p),
       this.parseParent(this.props.y, p, true),
@@ -502,7 +502,7 @@ Area.Line = class Line extends AreaComponent {
   }
 
   draw(area, p) {
-    const path = new libui.UiDrawPath(0 /*uiDrawFillModeWinding*/);
+    const path = new libui.UiDrawPath(libui.fillMode.winding);
     path.newFigure(
       this.parseParent(this.props.x1, p),
       this.parseParent(this.props.y1, p, true)
@@ -535,7 +535,7 @@ Area.Arc = class Arc extends AreaComponent {
   }
 
   draw(area, p) {
-    const path = new libui.UiDrawPath(0 /*uiDrawFillModeWinding*/);
+    const path = new libui.UiDrawPath(libui.fillMode.winding);
     path.newFigureWithArc(
       this.parseParent(this.props.x, p),
       this.parseParent(this.props.y, p, true),
@@ -573,7 +573,7 @@ Area.Circle = class Circle extends AreaComponent {
   }
 
   draw(area, p) {
-    const path = new libui.UiDrawPath(0 /*uiDrawFillModeWinding*/);
+    const path = new libui.UiDrawPath(libui.fillMode.winding);
     path.newFigureWithArc(
       this.parseParent(this.props.x, p),
       this.parseParent(this.props.y, p, true),
@@ -600,7 +600,7 @@ Area.Circle.defaultProps = {
 
 Area.Bezier = class Bezier extends AreaComponent {
   draw(area, p) {
-    const path = new libui.UiDrawPath(0 /*uiDrawFillModeWinding*/);
+    const path = new libui.UiDrawPath(libui.fillMode.winding);
     path.newFigure(
       this.parseParent(this.props.x1, p),
       this.parseParent(this.props.y1, p, true)

--- a/src/components/Area.js
+++ b/src/components/Area.js
@@ -26,6 +26,7 @@ const onMouse = component => (area, evt) => {
       width: evt.getAreaWidth(),
       height: evt.getAreaHeight(),
       button: down,
+      count: evt.getCount(),
     });
   } else {
     const buttons = [];


### PR DESCRIPTION
Functional changes:
- `onMouseUp` works correctly now
- `onMouseDown` now has access to the click count (e.g. for double clicks)
- the modifier and extKey parameters of the key events get translated from a number into string(s)
- missing cast in transform=scale

Otherwise:
- using enums instead of magic numbers
- calling free methods