### PR TITLE
Remove old code in Window

### DIFF
--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -76,10 +76,6 @@ class Window extends DesktopComponent {
       this.element.fullscreen = this.props.fullscreen;
       this.element.borderless = this.props.borderless;
 
-      if (this.props.centered) {
-        this.element.center();
-      }
-
       this.element.onContentSizeChanged(() => {
         this.props.onContentSizeChange({
           h: this.element.contentSize.h,


### PR DESCRIPTION
There is no UiWindow.center() function in libui-node anymore and the centered prop wasn't documented in proton-native.