### PR TITLE
fix: add the missing digit '5'

### DIFF
--- a/examples/Calculator/app.js
+++ b/examples/Calculator/app.js
@@ -126,9 +126,9 @@ export default class Calculator extends Component {
           onPress: () => this.addDigit(4),
         },
         {
-          text: '2',
+          text: '5',
           type: 'number',
-          onPress: () => this.addDigit(2),
+          onPress: () => this.addDigit(5),
         },
         {
           text: '6',


### PR DESCRIPTION
Currently, there is no number `5` in the app instead `2` is been used at its place.