### PR TITLE
TS 3.7.3+ existence guard on children.map

### DIFF
--- a/src/components/PickerInternal.ts
+++ b/src/components/PickerInternal.ts
@@ -82,7 +82,7 @@ export default (p: Props) => {
     },
     children: (children: PickerItem[]) => {
       if (
-        children.map(x => (x.props ? x.props.label : x)).toString() ==
+        children?.map?.(x => (x.props ? x.props.label : x)).toString() ==
         itemList.toString()
       )
         return;


### PR DESCRIPTION
Solves #250 , uses super-newly accepted ?. syntax; feel free to use older basic `children && children.map && ...` instead if needed.