### PR TITLE
Fix types for intrinsic elements

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -2,7 +2,17 @@ import propChecker from "../utils/propChecker";
 import propsUpdater from "../utils/propsUpdater";
 import { Component } from "./Base";
 
-export default (p: {}) => {
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      APP: React.PropsWithChildren<Props>
+    }
+  }
+}
+
+export interface Props {}
+
+export default (p: Props) => {
   const children: Component[] = [];
 
   const propTypes = {};

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -6,10 +6,18 @@ import convertStyleSheet from "../utils/convertStyleSheet";
 import { YogaComponent } from "./YogaComponent";
 import { getBackend } from "../backends/index";
 
-interface Props {
-  style: React.CSSProperties;
-  onPress: () => void;
-  title: string;
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      BUTTON: React.PropsWithChildren<Props>
+    }
+  }
+}
+
+export interface Props {
+  style?: React.CSSProperties;
+  onPress?: () => void;
+  title?: string;
 }
 
 export default (p: Props) => {
@@ -37,7 +45,9 @@ export default (p: Props) => {
   };
 
   element.buttonReleasedEvent(() => {
-    handlers.onPress();
+    if (handlers.onPress) {
+      handlers.onPress();
+    }
   });
 
   const containerProps = Container(

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -27,12 +27,20 @@ interface ImageStyle extends React.CSSProperties {
   resizeMode: ResizeMode;
 }
 
-interface Props {
-  style: React.CSSProperties;
-  onResponderGrant: () => void;
-  onResponderRelease: () => void;
-  resizeMode: ResizeMode;
-  source: ImageSource;
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      IMAGE: Props
+    }
+  }
+}
+
+export interface Props {
+  style?: React.CSSProperties;
+  onResponderGrant?: () => void;
+  onResponderRelease?: () => void;
+  resizeMode?: ResizeMode;
+  source?: ImageSource;
 }
 
 export default (p: Props) => {
@@ -78,11 +86,15 @@ export default (p: Props) => {
   };
 
   element.mousePressEvent(() => {
-    handlers.onResponderGrant();
+    if (handlers.onResponderGrant) {
+      handlers.onResponderGrant();
+    }
   });
 
   element.mouseReleaseEvent(() => {
-    handlers.onResponderRelease();
+    if (handlers.onResponderRelease) {
+      handlers.onResponderRelease();
+    }
   });
 
   const containerProps = Container(

--- a/src/components/PickerInternal.ts
+++ b/src/components/PickerInternal.ts
@@ -6,10 +6,18 @@ import convertStyleSheet from "../utils/convertStyleSheet";
 import { YogaComponent } from "./YogaComponent";
 import { getBackend } from "../backends/index";
 
-interface Props {
-  style: React.CSSProperties;
-  onValueChange: (text: string, index: number) => void;
-  selectedValue: string | number;
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      PICKERINTERNAL: React.PropsWithChildren<Props>
+    }
+  }
+}
+
+export interface Props {
+  style?: React.CSSProperties;
+  onValueChange?: (text: string, index: number) => void;
+  selectedValue?: string | number;
 }
 
 interface PickerItemProps {
@@ -48,7 +56,9 @@ export default (p: Props) => {
   };
 
   element.activatedEvent((text: string) => {
-    handlers.onValueChange(items[text] || text, element.currentIndex());
+    if (handlers.onValueChange) {
+      handlers.onValueChange(items[text] || text, element.currentIndex());
+    }
   });
 
   const containerProps = Container(

--- a/src/components/RootText.ts
+++ b/src/components/RootText.ts
@@ -3,18 +3,18 @@ import propsUpdater from "../utils/propsUpdater";
 import * as PropTypes from "prop-types";
 import { TextFuncs } from "./TextFuncs";
 import { YogaComponent } from "./YogaComponent";
-import { getBackend } from '../backends/index'
-
-interface Props {
-  style: React.CSSProperties;
-}
+import { getBackend } from '../backends/index';
 
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      ROOTTEXT: any;
+      ROOTTEXT: React.PropsWithChildren<Props>;
     }
   }
+}
+
+export interface Props {
+  style?: React.CSSProperties;
 }
 
 export default (p: Props) => {
@@ -49,7 +49,7 @@ export default (p: Props) => {
     element.setText(text);
     yogaProps.node.markDirty();
     yogaProps.f.f && yogaProps.f.f();
-  }, styleProp.s);
+  }, styleProp.s || {});
 
   updateProps(props);
 

--- a/src/components/TextInput.ts
+++ b/src/components/TextInput.ts
@@ -6,11 +6,19 @@ import convertStyleSheet from "../utils/convertStyleSheet";
 import { YogaComponent } from "./YogaComponent";
 import { getBackend } from "../backends/index";
 
-interface Props {
-  style: React.CSSProperties;
-  onChangeText: (text: string) => void;
-  value: string;
-  multiline: boolean;
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      TEXTINPUT: Props
+    }
+  }
+}
+
+export interface Props {
+  style?: React.CSSProperties;
+  onChangeText?: (text: string) => void;
+  value?: string;
+  multiline?: boolean;
 }
 
 export default (p: Props) => {
@@ -40,7 +48,9 @@ export default (p: Props) => {
   };
 
   element.textChangedEvent((text: string) => {
-    handlers.onChangeText(text);
+    if (handlers.onChangeText) {
+      handlers.onChangeText(text);
+    }
   });
 
   const containerProps = Container(

--- a/src/components/View.ts
+++ b/src/components/View.ts
@@ -6,18 +6,24 @@ import convertStyleSheet from "../utils/convertStyleSheet";
 import { YogaComponent } from "./YogaComponent";
 import { getBackend } from "../backends/index";
 
-interface Props {
-  style: React.CSSProperties;
-  onResponderGrant: () => void;
-  onResponderRelease: () => void;
-}
-
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      VIEW: any;
+      VIEW: React.PropsWithChildren<Props>;
     }
   }
+}
+
+type a = {
+  text?: string
+} & {
+  text: string
+}
+
+export interface Props {
+  style?: React.CSSProperties;
+  onResponderGrant?: () => void;
+  onResponderRelease?: () => void;
 }
 
 export default (p: Props) => {
@@ -46,11 +52,15 @@ export default (p: Props) => {
   };
 
   element.mousePressEvent(() => {
-    handlers.onResponderGrant();
+    if (handlers.onResponderGrant) {
+      handlers.onResponderGrant();
+    }
   });
 
   element.mouseReleaseEvent(() => {
-    handlers.onResponderRelease();
+    if (handlers.onResponderRelease) {
+      handlers.onResponderRelease();
+    }
   });
 
   const containerProps = Container(

--- a/src/components/VirtualText.ts
+++ b/src/components/VirtualText.ts
@@ -3,16 +3,16 @@ import propsUpdater from "../utils/propsUpdater";
 import * as PropTypes from "prop-types";
 import { TextFuncs } from "./TextFuncs";
 
-interface Props {
-  style: React.CSSProperties;
-}
-
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      VIRTUALTEXT: any;
+      VIRTUALTEXT: React.PropsWithChildren<Props>;
     }
   }
+}
+
+export interface Props {
+  style?: React.CSSProperties;
 }
 
 export default (p: Props) => {
@@ -36,7 +36,7 @@ export default (p: Props) => {
     }
   });
 
-  const textProps = TextFuncs(() => {}, styleProp);
+  const textProps = TextFuncs(() => {}, styleProp || {});
 
   updateProps(props);
 

--- a/src/components/Window.ts
+++ b/src/components/Window.ts
@@ -7,9 +7,17 @@ import convertStyleSheet from "../utils/convertStyleSheet";
 import { YogaComponent } from "./YogaComponent";
 import { getBackend } from "../backends/index";
 
-interface Props {
-  style: React.CSSProperties;
-  onResize: (size: { w: number; h: number }) => void;
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      WINDOW: React.PropsWithChildren<Props>;
+    }
+  }
+}
+
+export interface Props {
+  style?: React.CSSProperties;
+  onResize?: (size: { w: number; h: number }) => void;
 }
 
 export default (p: Props) => {
@@ -38,7 +46,9 @@ export default (p: Props) => {
 
   element.resizeEvent((w: number, h: number) => {
     ROOT_NODE.afterCommit(ROOT_NODE);
-    handlers.onResize({ w, h });
+    if (handlers.onResize) {
+      handlers.onResize({ w, h });
+    }
   });
 
   const percentToSize = (

--- a/src/components/YogaComponent.ts
+++ b/src/components/YogaComponent.ts
@@ -94,7 +94,7 @@ export const YogaComponent = (
       };
     };
 
-    node.setMeasureFunc((...args) => measure(...args));
+    node.setMeasureFunc(() => measure());
   }
 
   return {

--- a/src/utils/propChecker.ts
+++ b/src/utils/propChecker.ts
@@ -1,10 +1,10 @@
 import * as PropTypes from "prop-types";
 import * as _ from "lodash";
 
-function propChecker(
-  props: any,
-  propTypes: any,
-  defaultProps: any,
+function propChecker<P = any, T = any, D = any>(
+  props: P,
+  propTypes: T,
+  defaultProps: D,
   name: string
 ): any {
   // for (let prop in defaultProps) {


### PR DESCRIPTION
Intrinsic elements are now properly typed

Previously the intrinsic elements provided by proton-native (Window, View, App, VirtualText, RootText, Image, TextInput, PickerInternal, Button) had few or no types associated with them. This made it difficult to use proton-native in typescript projects