### PR TITLE
support for array style as in react native

### DIFF
--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -22,13 +22,18 @@ export interface Props {
 
 export default (p: Props) => {
   const propTypes = {
-    style: PropTypes.object,
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    ),
     onPress: PropTypes.func,
     title: PropTypes.string
   };
   const defaultProps = {
     style: {},
-    onPress: () => {},
+    onPress: () => { },
     title: "Button"
   };
 

--- a/src/components/Image.ts
+++ b/src/components/Image.ts
@@ -45,7 +45,12 @@ export interface Props {
 
 export default (p: Props) => {
   const propTypes = {
-    style: PropTypes.object,
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    ),
     onResponderGrant: PropTypes.func,
     onResponderRelease: PropTypes.func,
     resizeMode: PropTypes.oneOf([

--- a/src/components/PickerInternal.ts
+++ b/src/components/PickerInternal.ts
@@ -31,7 +31,12 @@ interface PickerItem {
 
 export default (p: Props) => {
   const propTypes = {
-    style: PropTypes.object,
+    sstyle: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    ),
     onValueChange: PropTypes.func,
     selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
   };

--- a/src/components/RootText.ts
+++ b/src/components/RootText.ts
@@ -19,7 +19,12 @@ export interface Props {
 
 export default (p: Props) => {
   const propTypes = {
-    style: PropTypes.object
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    )
   };
   const defaultProps = {
     style: {}

--- a/src/components/TextInput.ts
+++ b/src/components/TextInput.ts
@@ -23,7 +23,12 @@ export interface Props {
 
 export default (p: Props) => {
   const propTypes = {
-    style: PropTypes.object,
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    ),
     onChangeText: PropTypes.func,
     value: PropTypes.string,
     multiline: PropTypes.bool

--- a/src/components/View.ts
+++ b/src/components/View.ts
@@ -40,7 +40,12 @@ export interface Props {
 
 export default (p: Props) => {
   const propTypes = {
-    style: PropTypes.object,
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    ),
     onResponderGrant: PropTypes.func,
     onResponderRelease: PropTypes.func,
     onMouseMove: PropTypes.func,

--- a/src/components/VirtualText.ts
+++ b/src/components/VirtualText.ts
@@ -17,7 +17,12 @@ export interface Props {
 
 export default (p: Props) => {
   const propTypes = {
-    style: PropTypes.object
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    )
   };
   const defaultProps = {
     style: {}

--- a/src/components/Window.ts
+++ b/src/components/Window.ts
@@ -24,7 +24,12 @@ export interface Props {
 
 export default (p: Props) => {
   const propTypes = {
-    style: PropTypes.object,
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    ),
     onResize: PropTypes.func
   };
   const defaultProps = {

--- a/src/react-components/Text.tsx
+++ b/src/react-components/Text.tsx
@@ -9,7 +9,12 @@ export default class Text extends React.Component {
     style: {}
   };
   static propTypes = {
-    style: PropTypes.object
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    )
   };
   render() {
     return (

--- a/src/react-components/TouchableHighlight.tsx
+++ b/src/react-components/TouchableHighlight.tsx
@@ -34,7 +34,12 @@ export default class TouchableHighlight extends React.Component<Props, State> {
   static propTypes = {
     activeOpacity: PropTypes.number,
     underlayColor: PropTypes.string,
-    style: PropTypes.object,
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    ),
     onPress: PropTypes.func,
     onLongPress: PropTypes.func
   };

--- a/src/react-components/TouchableOpacity.tsx
+++ b/src/react-components/TouchableOpacity.tsx
@@ -29,7 +29,12 @@ export default class TouchableOpacity extends React.Component<Props, State> {
   };
   static propTypes = {
     activeOpacity: PropTypes.number,
-    style: PropTypes.object,
+    style: PropTypes.oneOfType(
+      [
+        PropTypes.object,
+        PropTypes.array,
+      ]
+    ),
     onPress: PropTypes.func,
     onLongPress: PropTypes.func
   };

--- a/src/utils/convertStyleSheet.ts
+++ b/src/utils/convertStyleSheet.ts
@@ -37,8 +37,10 @@ const excluded = [
 
 const convertToPx = ["fontSize"];
 
-const convertStyleSheet = (style: React.CSSProperties) =>
-  Object.entries(style).reduce((styleString, [propName, propValue]) => {
+const convertStyleSheet = (style: React.CSSProperties) => {
+  style = Array.isArray(style)? Object.assign({}, ...style.flat(2)): style
+  
+  return Object.entries(style).reduce((styleString, [propName, propValue]) => {
     if (excluded.includes(propName)) {
       return styleString;
     }
@@ -54,5 +56,7 @@ const convertStyleSheet = (style: React.CSSProperties) =>
 
     return `${styleString}${propName}:${propValue};`;
   }, "");
+}
+ 
 
 export default convertStyleSheet;


### PR DESCRIPTION
React Native has support for array style ([{ backgroundColor: 'red' }, {fontSize: 10}]), this allows libraries like styled-components to work in react-native.